### PR TITLE
Installation fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ There are two methods that you can use to install this BSP. We highly recommend 
  1. [Download and install the Arduino IDE](https://www.arduino.cc/en/Main/Software) (At least v1.6.12)
  2. Start the Arduino IDE
  3. Go into Preferences
- 4. Add "https://raw.githubusercontent.com/pdcook/nRFMicro-Arduino-Core/main/package_nRFMicro_index.json" as an 'Additional Board Manager URL'
+ 4. Add the following lines as 'Additional Board Manager URL'
+
+   ```
+    https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json
+    https://raw.githubusercontent.com/pdcook/nRFMicro-Arduino-Core/main/package_nRFMicro_index.json
+   ```
+
  5. Restart the Arduino IDE
  6. Open the Boards Manager from the Tools -> Board menu and install 'nRFMicro Boards'
  7. Once the BSP is installed, select 'nRFMicro' or 'SuperMini nRF52840' from the Tools -> Board menu, which will update your system config to use the right compiler and settings for the nRF52.

--- a/package_nRFMicro_index.json
+++ b/package_nRFMicro_index.json
@@ -1,7 +1,7 @@
 {
   "packages": [
     {
-      "name": "nRFMicro-like Boards",
+      "name": "nRFMicro-like-Boards",
       "maintainer": "pdcook",
       "websiteURL": "https://github.com/pdcook/nRFMicro-Arduino-Core",
       "email": "",
@@ -10,7 +10,7 @@
       },
       "platforms": [
         {
-          "name": "nRFMicro-like Boards",
+          "name": "nRFMicro-like-Boards",
           "architecture": "nrf52",
           "version": "1.0.0",
           "category": "Contributed",
@@ -56,7 +56,7 @@
           ]
         },
         {
-          "name": "nRFMicro-like Boards",
+          "name": "nRFMicro-like-Boards",
           "architecture": "nrf52",
           "version": "1.0.1",
           "category": "Contributed",
@@ -102,7 +102,7 @@
           ]
         },
         {
-          "name": "nRFMicro-like Boards",
+          "name": "nRFMicro-like-Boards",
           "architecture": "nrf52",
           "version": "1.0.2",
           "category": "Contributed",


### PR DESCRIPTION
Following the comments from reported issue I updated the json file and the instructions to apply the fixups reported there.

I tried this with a clean installation in Linux and it worked fine, I could download the board package and select the promicro/nice boards without issues. I also tried to compile a couple of USB and nrfCrypto samples and they seem to build as well.

Hope that helps